### PR TITLE
bugfix don't escape HTML special chars in solidity template

### DIFF
--- a/v1.0/caterpillar-core/templates/bpmn2sol.ejs
+++ b/v1.0/caterpillar-core/templates/bpmn2sol.ejs
@@ -45,7 +45,7 @@ contract <%= nodeName(processId()) %>_Contract {
 <%    oracleTaskMap.forEach((oracleKey, nodeId, map) => { -%>
     uint active_<%= nodeName(nodeId) %> = 0;    
 <% })} -%>
-    <%= globalDeclarations() -%>
+    <%- globalDeclarations() -%>
 
     function <%= nodeName(processId()) %>_Contract() {
         owner = msg.sender;


### PR DESCRIPTION
If you use HTML special characters in the global definitions of the bpmn process (e.g. a mapping `mapping (uint => address) aMapping`), they will be HTML escaped in the final solidity code (in the example `mapping (uint =&gt; address) aMapping`).

This PR fixes this issue. Since the template doesn't generate HTML it should be safe to use the non-escaping EJS tag (`<%-` )